### PR TITLE
Add feature clamscan-sssp and fixed some minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python SSSP client.
 
 SSSP - the Sophos Simple Scanning Protocol - is a protocol to talk to a persistant sophos virus scanner and feed data to it.
 
-Protocol details can be found at https://www.sophos.com/en-us/medialibrary/PDFs/documentation/savi_sssp_13_meng.pdf
+Protocol details can be found at https://www.sophos.com/en-us/medialibrary/PDFs/documentation/savi\_sssp\_13\_meng.pdf
 For this to work, the SAV Dynamic Interface daemon needs to be running as well as a sophos AV daemon. Refer to https://www.sophos.com/en-us/medialibrary/PDFs/documentation/SAVDI-User-Manual.pdf for more details.
 
 Example use:
@@ -13,3 +13,10 @@ $ sssp.py eicar.com
 (False, 'Message is infected with EICAR-AV-Test')
 $
 ```
+
+Clamscan wrapper to read from stdin and scan via SAVDI TCP socket
+```
+$ clamscan-sssp -S inet:127.0.0.1:4020 -
+
+```
+This is useful to scan files on request with OwnCloud/Nextcloud's files\_antivirus app

--- a/clamscan-sssp
+++ b/clamscan-sssp
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# ClamAV emulator to scan mail via SSSP for viruses
+#
+#   Copyright 2018,2019 Andreas Thienemann <andreas@bawue.net> and
+#   Copyright 2019 Jan-Jonas Sämann <jan-jonas.saemann@saenet.de>
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import argparse
+import os
+import socket
+import sys
+import syslog
+import sssp
+import traceback
+
+global args
+
+class ssspPipe():
+  name = 'clam-scan'
+
+  def log(self, msg):
+      syslog.syslog('{}: {}'.format(self.name, msg))
+
+  def file(self, name):
+    try:
+      scanner = sssp.sssp(args.sssp_socket)
+      if not scanner.selftest():
+        self.log('SAVDI selftest failed. Not scanning.')
+        return (2,'Unknown: ERROR')
+      if name == '-':
+        with sys.stdin as f:
+          result, msg = scanner.check(f.read())
+      else:
+        with open(name, 'r') as f:
+          result, msg = scanner.check(f.read())
+    except:
+      self.log('Unknown SAVDI Error. {}'.format(traceback.format_exc()))
+      return (2,'Unknown: ERROR')
+
+    engine = scanner.query_engine()
+    server = scanner.query_server()
+    if result:
+      self.log('{}, is clean.'.format(name))
+    else:
+      self.log('File {} reported infected with {} by SAVDI.'.format(name, msg.split()[-1]))
+      return (1, 'Infected: {} FOUND'.format(msg.split()[-1]))
+    return (0,'Data: OK')
+
+def main():
+  global args
+
+  syslog.openlog(ident='clam-scan', logoption=syslog.LOG_PID, facility=syslog.LOG_DAEMON)
+  syslog.syslog('ClamAV emulator starting using socket {}'.format(args.sssp_socket))
+  pipe = ssspPipe()
+  scan_rc, scan_result = pipe.file(args.file)
+  syslog.syslog('ClamAV emulator stopping')
+  syslog.closelog()
+  if scan_result:
+    print(scan_result)
+  return scan_rc
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='ClamAV emulator scans files for viruses via Sophos SSSP.')
+  parser.add_argument('-q', '--quarantine', action='store_true', default=False, help='Not implemented yet')
+  parser.add_argument('-r', '--remove', action='store_true', default=False, help='Drop original file if ')
+  parser.add_argument('-S', '--sssp_socket', default='/var/run/savdid/savdid.sock', help='Socket for communicating to sssp interface.')
+  parser.add_argument('file', help='File to scan or - to read from stdin')
+  args = parser.parse_args()
+
+  rc = main()
+  sys.exit(rc)

--- a/sssp.py
+++ b/sssp.py
@@ -41,11 +41,11 @@ class SSSPOptionError(SSSPError):
     super(SSSPOptionError, self).__init__(msg)
 
 class sssp():
-  def __init__(self, socket='/var/run/savdi/sssp.sock'):
+  def __init__(self, sock='/var/run/savdi/sssp.sock'):
     # The eicar string is ROT13 encoded to prevent virus scanners from triggering a
     # false alarm
     self.eicar = "K5B!C%@NC[4\\CMK54(C^)7PP)7}$RVPNE-FGNAQNEQ-NAGVIVEHF-GRFG-SVYR!$U+U*"
-    self.sssp_socket = socket
+    self.sssp_socket = sock
     self.sssp_version = 1.0
     self.timeout = 2
     self.maxwait = 30
@@ -56,19 +56,19 @@ class sssp():
 
   def connect(self):
     """Connect to SSSP socket"""
-    if self.socket[0] == '/':
+    if self.sssp_socket[0] == '/':
       self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-      socket = self.sssp_socket
-    elif self.socket.startswith('inet:'):
+      sock = self.sssp_socket
+    elif self.sssp_socket.startswith('inet:'):
       self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       _, bind_host, port = self.sssp_socket.split(':')
-      socket = (bind_host, port)
+      sock = (bind_host, port)
     elif isinstance(self.socket, tuple):
       self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-      socket = self.sssp_socket
+      sock = self.sssp_socket
 
     self.s.settimeout(self.timeout)
-    self.s.connect(socket)
+    self.s.connect(sock)
 
   def _recv_line(self):
     line = []

--- a/sssp.py
+++ b/sssp.py
@@ -62,7 +62,7 @@ class sssp():
     elif self.sssp_socket.startswith('inet:'):
       self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       _, bind_host, port = self.sssp_socket.split(':')
-      sock = (bind_host, port)
+      sock = (bind_host, int(port))
     elif isinstance(self.socket, tuple):
       self.s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
       sock = self.sssp_socket


### PR DESCRIPTION
This commit fixes some minor issues. It introduces a new feature for scanning arbitrary data from command-line stdin or file. clamscan-sssp is made to be a drop-in-replacement for ClamAV.
The latter can be used to integrate Sophos antivirus into webbased cloud frontends like Nextcloud using it's files_antivirus app. Using SAVDI is important due to otherwise huge latencies by scanning files  directly with SAV's savscan command.